### PR TITLE
Such changes.

### DIFF
--- a/GSI/GApps/empty-permissions.xml
+++ b/GSI/GApps/empty-permissions.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0"?> 
+<permissions>
+</permissions>

--- a/GSI/GApps/gapps.mk
+++ b/GSI/GApps/gapps.mk
@@ -1,0 +1,28 @@
+PRODUCT_COPY_FILES += \
+        vendor/bootleggers/GApps/empty-permission.xml:system/etc/permissions/com.google.android.camera2.xml \
+        vendor/bootleggers/GApps/empty-permission.xml:system/etc/permissions/com.google.android.camera.experimental2015.xml \
+        vendor/bootleggers/GApps/empty-permission.xml:system/etc/permissions/com.google.android.camera.experimental2016.xml \
+        vendor/bootleggers/GApps/empty-permission.xml:system/etc/permissions/com.google.android.camera.experimental2017.xml
+
+DEVICE_PACKAGE_OVERLAYS += vendor/bootleggers/GApps/overlay-gapps
+
+GAPPS_VARIANT := nano
+DONT_DEXPREOPT_PREBUILTS := true
+WITH_DEXPREOPT_BOOT_IMG_AND_SYSTEM_SERVER_ONLY := true
+GAPPS_FORCE_PACKAGE_OVERRIDES := true
+GAPPS_FORCE_BROWSER_OVERRIDES := true
+GAPPS_FORCE_WEBVIEW_OVERRIDES := true
+GAPPS_FORCE_DIALER_OVERRIDES := true
+GAPPS_FORCE_MMS_OVERRIDES := true
+
+PRODUCT_PACKAGES += \
+       Chrome \
+       CalculatorGoogle \
+       PrebuiltDeskClockGoogle \
+       CalendarGooglePrebuilt \
+       LatinImeGoogle \
+       Facelock \
+       phh-overrides
+
+$(call inherit-product, vendor/opengapps/build/opengapps-packages.mk)
+

--- a/GSI/GApps/overlay-gapps/frameworks/base/core/res/res/values/config.xml
+++ b/GSI/GApps/overlay-gapps/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+	<string name="config_defaultAutofillService">com.google.android.gms/.autofill.service.AutofillService</string>
+	<string name="config_defaultAccessibilityService">com.google.android.marvin.talkback/.TalkBackService</string>
+	<string name="config_persistentDataPackageName">com.google.android.gms</string>
+	<string name="config_defaultNetworkRecommendationProviderPackage">com.google.android.gms</string>
+</resources>

--- a/GSI/bootleg.mk
+++ b/GSI/bootleg.mk
@@ -10,8 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # Basically, you can GTFO and chill the F out if somethings goes into the shitter.
-# And on a side note, the explosion of your device, is considered as a success
-# to us.
+# And on a side note, the explosion of your device, is considered as a success to us.
 # Cheers.
 
 $(call inherit-product, vendor/bootleggers/config/common_full_phone.mk)

--- a/GSI/bootleg.mk
+++ b/GSI/bootleg.mk
@@ -1,0 +1,22 @@
+# Bootleggers of all Nations 2018 (c)
+#
+# Licensed under the NOICE license.
+# You may not use this file except in compliance with ser BhoLTE.
+# You may obtain a copy (bootleg ofc) of this license at:
+#
+#       https://bootleggersrom.github.io/NOICE/
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# Basically, you can GTFO and chill the F out if somethings goes into the shitter.
+# And on a side note, the explosion of your device, is considered as a success
+# to us.
+# Cheers.
+
+$(call inherit-product, vendor/bootleggers/config/common_full_phone.mk)
+
+DEVICE_MAINTAINERS="Francesco M. (Dil3mm4)"
+BOOTLEG_BUILD_TYPE="Shishufied"
+
+

--- a/GSI/gsi.mk
+++ b/GSI/gsi.mk
@@ -1,0 +1,10 @@
+# Such Bootleg
+$(call inherit-product vendor/bootleggers/GSI/bootleg.mk)
+
+# Wow, GApps
+$(call inherit-product, vendor/bootleggers/GSI/GApps/gapps.mk)
+
+# Noice overlays
+DEVICE_PACKAGE_OVERLAYS += vendor/bootleggers/GSI/overlays
+
+

--- a/GSI/overlays/frameworks/base/packages/systemui/res/values/dimens.xml
+++ b/GSI/overlays/frameworks/base/packages/systemui/res/values/dimens.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+* Bootleggers of all Nations 2018 (c)
+*
+* Licensed under the NOICE license.
+* You may not use this file except in compliance with ser BhoLTE.
+* You may obtain a copy (bootleg ofc) of this license at:
+*
+*       https://bootleggersrom.github.io/NOICE/
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* Basically, you can GTFO and chill the F out if somethings goes into the shitter.
+* And on a side note, the explosion of your device, is considered as a success to us.
+* Cheers.
+-->
+<resources>
+<dimen name="dozing_big_clock_padding" format="float">0.38</dimen>
+</resources>
+


### PR DESCRIPTION
GApps: experimental camera features deserves to be ignored;
       inheriting nano package plus faceunlock;
       overlays for NOICE experience;

btlg:  bootleg makefile;
       overlay for doze clock size;

gsi:   all this jazz is called by gsi.mk that has to be
       inherited over your GSI device tree;