### PR TITLE
bootanimation: fixup manual picking

### DIFF
--- a/bootanimation/generate-bootanimation.sh
+++ b/bootanimation/generate-bootanimation.sh
@@ -34,23 +34,26 @@ mkdir -p "$OUT/bootanimation"
 #   9: Moelle's Smoke Pulse: The one that got shared everywhere, that ends on a smokey background.
 #
 #####
-if [[ $SINGLE_BOOT != "false" ]] && [[ $PICK_BOOT != "false" ]]; then
-    RANDOM_BOOT="$PICK_BOOT"
-    echo "Info: bootanimation was chosen manually. The chosen one is the number $RANDOM_BOOT"
-elif [[ $PICK_BOOT != "false" ]]; then
-    RANDOM_BOOT="${PICK_BOOT// /}"
-    RANDOM_BOOT="${RANDOM_BOOT:$BUILDNUM-1:1}"
-    echo "Info: bootanimation was chosen manually. The chosen one is the number $RANDOM_BOOT"
-else
-    # make sure the RANDOM_BOOT hasn't been chosen before
-    BOOTANIM_NUMS="$OUT/../.bootanimation_numbers"
-    RANDOM_BOOT=$(shuf -i 0-9 -n 1)
-    touch $BOOTANIM_NUMS
-    until ! cat $BOOTANIM_NUMS | grep $RANDOM_BOOT &>/dev/null; do
+choose_random() {
+    # choose a random animation, and make sure it isn't already chosen
+    touch $OUT/../.bootanimation_numbers
+    BOOTANIM_NUMS=$(cat $OUT/../.bootanimation_numbers)
+    while [[ "$BOOTANIM_NUMS" =~ $RANDOM_BOOT ]]; do
         RANDOM_BOOT=$(shuf -i 0-9 -n 1)
     done
-    echo $RANDOM_BOOT >> $BOOTANIM_NUMS
+    echo $RANDOM_BOOT >> $OUT/../.bootanimation_numbers
     echo "Info: bootanimation was chosen randomly. The chosen one is the number $RANDOM_BOOT"
+}
+
+if [[ $PICK_BOOT != "false" ]]; then
+    RANDOM_BOOT="$(cut -d, -f $BUILDNUM <<< $PICK_BOOT)"
+    if [[ -z $RANDOM_BOOT ]]; then
+        choose_random   # if RANDOM_BOOT is blank, pick a different animation randomly.
+    else
+        echo "Info: bootanimation was chosen manually. The chosen one is the number $RANDOM_BOOT"
+    fi
+else
+    choose_random
 fi
 
 case "$RANDOM_BOOT" in


### PR DESCRIPTION
This fixes manual picking while setting the variable via make.

Now instead of doing `export TARGET_PICK_BOOTANIMATION="x y z"`, now we
do `export TARGET_PICK_BOOTANIMATION="x,y,z"`.

Thank you @Eldianosar for the comma idea

Signed-off-by: shagbag913 <sh4gbag913@gmail.com>