### PR TITLE
vendor: set our own date prop

### DIFF
--- a/build/core/main_version.mk
+++ b/build/core/main_version.mk
@@ -6,4 +6,5 @@ ADDITIONAL_BUILD_PROPERTIES += \
     ro.bootleggers.buildshort=$(BOOTLEGGERS_MOD_SHORT) \
     ro.bootleggers.songcodename=$(PRODUCT_VERSION_MINOR) \
     ro.bootleggers.songcodeurl=$(BOOTLEGGERS_SONGCODEURL) \
-    ro.bootleggers.display.version=$(BOOTLEGGERS_VERSION)
+    ro.bootleggers.display.version=$(BOOTLEGGERS_VERSION) \
+    ro.bootleggers.build.date=$(BOOTLEGGERS_EPOCH)

--- a/config/common.mk
+++ b/config/common.mk
@@ -6,7 +6,8 @@ PRODUCT_VERSION_MAJOR = Pie
 PRODUCT_VERSION_MINOR = niceparse.Goodbye_Star_Girl
 BOOTLEGGERS_VERSION_NUMBER := 4.0-Stable
 BOOTLEGGERS_SONGCODEURL = http://bit.ly/2Aa2WmA
-BOOTLEGGERS_POSTFIX := -$(shell date +"%Y%m%d-%H%M%S")
+BOOTLEGGERS_EPOCH := $(shell date +%s)
+BOOTLEGGERS_POSTFIX := -$(shell date -d @$(BOOTLEGGERS_EPOCH) +"%Y%m%d-%H%M%S")
 
 ifndef BOOTLEGGERS_BUILD_TYPE
     BOOTLEGGERS_BUILD_TYPE := Unshishufied


### PR DESCRIPTION
This may seem stupid, however. ATM, our ro.build.date.utc does not match
up with the zip file name. This is because these get set at different
times. Since ShishuOTA relies on ro.build.date.utc & the zip name being
the same, using ro.build.date.utc makes ShishuOTA think there is an
update after flashing.

Signed-off-by: shagbag913 <sh4gbag913@gmail.com>